### PR TITLE
 Pequenas mudanças no comando 'remlang'

### DIFF
--- a/commands/remlang.js
+++ b/commands/remlang.js
@@ -14,7 +14,7 @@ exports.run = (client, message, args) => {
 
     /** Então verificamos os argumentos e instanciamos o cargo que queremos pelo nome. */
     let langs = langmgr.getLanguages();
-    let role = langs.find(l => l.toLowerCase() === args.join(' '));
+    let role = langs.find(l => l.toLowerCase() === args.join(' ').toLowerCase());
 
     if (!role)
     {

--- a/commands/remlang.js
+++ b/commands/remlang.js
@@ -1,35 +1,32 @@
 ﻿/**
- * O Comando "remlang" removera os cargos de programação dos membros.
+ * O Comando "remlang" removerá os cargos de programação dos membros.
  */
+const LanguageManager = require("../utils/languagemanager");
+const langmgr = new LanguageManager();
 
 /** Primeiro o metodo run(client, message, args) será executado pelo nosso arquivo message.js
- * Que passara os argumentos atraves do middleware que programamos.
+ * Que passará os argumentos atraves do middleware que programamos.
  */
 exports.run = (client, message, args) => {
 
-    /** Verificamos se o numero de argumentos é o correto. */
-    if (!(args.length === 1)) return message.reply(`?? Talvez isso possa ajuda-lo: \`\`\`${message.settings.PREFIX}${this.help.usage}\`\`\``);
+    /** Verificamos se o número de argumentos é válido. */
+    if (args.length < 1) return message.reply(`?? Talvez isso possa ajudá-lo: \`\`\`${message.settings.PREFIX}${this.help.usage}\`\`\``);
 
     /** Então verificamos os argumentos e instanciamos o cargo que queremos pelo nome. */
-    let role;
-    
     let langs = langmgr.getLanguages();
-    let idx = langs.map(x => x.toLowerCase()).indexOf(args[0].toLowerCase());
+    let role = langs.find(l => l.toLowerCase() === args.join(' '));
 
-    if (idx != -1) {
-        role = message.guild.roles.find("name", langs[idx]);
-    }
-    else
+    if (!role)
     {
         const emoji = message.guild.emojis.find("name", "thinkkk");
-        message.react((emoji) ? emoji : "🤔");
-        return message.reply(`?? Talvez isso possa ajuda-lo: \`\`\`${message.settings.PREFIX}addlang [${langs.join("|")}]\`\`\``);
+        message.react(emoji || "🤔");
+        return message.reply(`?? Talvez isso possa ajudá-lo: \`\`\`${message.settings.PREFIX}addlang [${langs.join("|")}]\`\`\``);
     }
 
     /** Logo então removemos o cargo do membro e mandamos uma mensagem como resposta
      * Caso o membro não possua o cargo então é enviada uma mensagem retornando.
      */
-    if (!message.member.roles.exists("name", role.name))
+    if (!message.member.roles.has(role.id))
     {
         return message.reply(`Você não possui esse cargo!`);
     }
@@ -41,14 +38,12 @@ exports.run = (client, message, args) => {
 };
 
 /** Aqui podemos colocar mais algumas configurações do comando. */
-exports.conf = {
-
-};
+exports.conf = {};
 
 /** Aqui exportamos ajuda do comando como o seu nome categoria descrição etc... */
 exports.help = {
     name: "remlang",
     category: "Moderação",
-    description: "Remove um cargo de alguma linguagem de programação a si proprio.",
+    description: "Remove um cargo de alguma linguagem de programação a si próprio.",
     usage: "remlang [java|c|c++|c#|python|kotlin|scala|go|javascript|php|swift|ruby|elixir|rust|assembly]"
-}
+};


### PR DESCRIPTION
- Agora o comando aceita mais de um argumento, permitindo a existência de cargos com nomes contendo espaço.
- Melhora a forma como o cargo é instanciado.