### PR TITLE
Add movemessage cmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,8 @@
 
 
 ## Um projeto totalmente livre
-Nós da Liga dos Programadores sempre nos preocupamos em ajudar entusiastas em programação ou pessoas que se interessam pelo assunto, assim então decidimos criar projetos de codigo 100% livre para ajudar estudantes ou novatos da área a se familiarizarem com códigos úteis e interessantes!
-  
-Fizemos este projeto, visando quem quer se aprofundar mais em bots para o Discord e JavaScript. Combinamos as melhores práticas do JavaScript para criar um bot estruturado simples e funcional que possui funções como Command Handlers, Event Handlers e um comando help bonito e automático!
+
+Fizemos este projeto, visando quem quer se aprofundar mais em bots para o Discord e JavaScript. Combinamos as melhores práticas do JavaScript para criar um bot estruturado simples e funcional que possui funções como Command Handlers e Event Handlers!
 
 ## Instalação
 Após ter clonado o repositorio e extraído todos arquivos. tenha certeza que possui o [npm](https://www.npmjs.com/) e o [node.js 8.0.0](https://nodejs.org/en/) ou mais recente. caso estiver com tudo pronto então execute o seguinte comando no diretorio dos arquivos.

--- a/commands/movemessage.js
+++ b/commands/movemessage.js
@@ -11,6 +11,8 @@ module.exports = {
       */
     run: function (client, message, args) {
 
+      if (!message.member.hasPermission('MANAGE_MESSAGES')) return message.reply('você não tem permissão para usar esse comando!');
+
       // Criando embed que será enviado para o usuário
       let embed = new RichEmbed()
 

--- a/commands/movemessage.js
+++ b/commands/movemessage.js
@@ -1,0 +1,57 @@
+const { RichEmbed } = require('discord.js');
+
+/**
+* O Comando "movemessage" vai mover uma mensagem do usuário de uma sala até outra, e em seguida apagar. Para sempre manter as conversas organizadas em suas salas
+*/
+
+module.exports = {
+    /**
+      * Primeiro o metodo run(client, message, args) será executado pelo nosso arquivo message.js
+      * Que passará os argumentos atraves do middleware que programamos.
+      */
+    run: function (client, message, args) {
+
+      // Criando embed que será enviado para o usuário
+      let embed = new RichEmbed()
+
+      message.channel.fetchMessage(args[0]) //buscando a mensagem que o bot vai mover
+        .then( msg => {
+          
+          //atribuindo a mensagem ao embed
+          embed.setAuthor( msg.author.username, msg.author.avatarURL, 'https://discord.js.org')
+	             .setDescription(msg.content)
+	             .setTimestamp()
+	             .setFooter('moveu esta mensagem', message.author.avatarURL);
+
+          //buscando o canal onde vai ser reposto
+          client.channels.find('id', args[1])
+            .send(`${msg.author} sua mensagem foi movida para esta sala`, embed)//enviando para o canal destino
+
+          msg.delete() //deletando a mensagem no canal antigo
+            .then(msg => console.log(`Mensagem de ${msg.author.username} movida`))
+            .catch(err => console.warn(err));
+        })
+        .catch(err => {
+          message.channel.send('ops, foi digitado algo errado! tente novamente...'); //caso o bot encontre algum problema
+          console.warn(err);
+        });
+
+    },
+    /**
+      * Aqui podemos colocar mais algumas configurações do comando.
+      */
+    conf: {},
+  
+    /**
+      * Aqui exportamos ajuda do comando como o seu nome categoria, descrição, etc...
+      */
+    get help () {
+      return {
+        name: 'movemessage',
+        category: 'Moderação',
+        description: 'Acão de movimento de mensagem para organização.',
+        usage: 'movemessage'
+      }
+    }
+  }
+  


### PR DESCRIPTION
Como este comando o moderador pode mover mensagens de tópicos errados.

Exemplo:

pessoa X manda dúvida de java no tópico de python:
```!movemessage id_messagem id_canal_java```

Por enquanto não está implementado opção de aceitar "#nome-sala"