### PR TITLE
fix cat response status code

### DIFF
--- a/commands/diversão/cat.js
+++ b/commands/diversão/cat.js
@@ -29,7 +29,7 @@ module.exports = {
       let data = ''
 
       // Caso ocorra um erro
-      if (res.statusCode !== '200') {
+      if (res.statusCode !== 200) {
         message.reply('Infelizmente eu não consegui pegar uma foto de gato para você. 😔')
         return
       }


### PR DESCRIPTION
As per the documentation, the status code is a number, not a string.

https://nodejs.org/api/http.html#http_http_get_options_callback